### PR TITLE
XSL url updated

### DIFF
--- a/lepidemo.ipynb
+++ b/lepidemo.ipynb
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url_xsl = \"https://raw.githubusercontent.com/HugoSchtr/xslt-playground/modif_xmlpagetotei_xsl/xmlpage_to_tei/xmlpage_to_tei.xsl\"\n",
+    "url_xsl = \"https://raw.githubusercontent.com/lectaurep/page2tei/main/xmlpage_to_tei.xsl\"\n",
     "\n",
     "# if running locally\n",
     "path_to_xsl = os.path.join(os.path.abspath(\".\"),(os.path.basename(url_xsl)))\n",
@@ -1291,7 +1291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since we created a repo for the XSL itself (https://github.com/lectaurep/page2tei/blob/main/xmlpage_to_tei.xsl), I've updated the URL used to download it from said repo in the jupyter notebook. 

There was also an automatic modification concerning the Python version used in the notebook. I don't know if that could cause any compatibility issues? 