### PR TITLE
Requests library import fixed and tei file name updated

### DIFF
--- a/lepidemo.ipynb
+++ b/lepidemo.ipynb
@@ -84,14 +84,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7237e5e4-37f9-487d-98ba-198a5830e159",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "29547a5f-4823-4e29-b7d0-e04d7e6cea85",
    "metadata": {},
@@ -122,6 +114,7 @@
     "from bs4 import BeautifulSoup, NavigableString\n",
     "import itertools\n",
     "from lxml import etree\n",
+    "import requests\n",
     "from tqdm.notebook import trange, tqdm\n",
     "\n",
     "# if running on colab, you'll need to install the corresponding files first\n",
@@ -540,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "id": "88640901-db1b-4318-9e36-63c39751ef4a",
    "metadata": {},
    "outputs": [],
@@ -596,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "id": "356c0208-8894-4e68-b158-a44f3ffd1f4d",
    "metadata": {},
    "outputs": [],
@@ -626,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "id": "d40ac73a-8d82-478c-9758-20eb7ce8f968",
    "metadata": {},
    "outputs": [],
@@ -738,7 +731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "id": "030a708b-ffbe-47ce-b16d-38c1c1f89bb5",
    "metadata": {},
    "outputs": [],
@@ -804,7 +797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 19,
    "id": "56de95ec-4874-4429-9749-d87bb6e9fab9",
    "metadata": {},
    "outputs": [
@@ -812,8 +805,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/achague-vm/Documents/lepidemo/env/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'escriptorium.inria.fr'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
-      "  InsecureRequestWarning,\n"
+      "/home/hugoscheithauer/Dev/lepidemo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'escriptorium.inria.fr'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
+      "  warnings.warn(\n"
      ]
     }
    ],
@@ -845,7 +838,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "id": "f3b1132d-60b0-4107-a557-d5ca271d0594",
    "metadata": {},
    "outputs": [
@@ -853,7 +846,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-------: FRAN_0025_3657_L-1.xml :-------\n",
+      "-------: FRAN_0025_5094_L-1.xml :-------\n",
       "starting conversion\n",
       "conversion finished\n",
       "Done parsing file\n",
@@ -864,12 +857,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0a45b3bfb1044fb6a311e19faa843807",
+       "model_id": "827bb05767814fb196ae7afabf4b6071",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/20 [00:00<?, ?it/s]"
+       "  0%|          | 0/21 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -882,7 +875,7 @@
       "Done building rows\n",
       "Done cleaning\n",
       "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_3657_L-1-tei.xml\n",
+      "saving to content/tei4publisher/FRAN_0025_5094_L-1.tei.xml\n",
       "-------: DAFANCH96_023MIC07633_L-0.xml :-------\n",
       "starting conversion\n",
       "conversion finished\n",
@@ -894,7 +887,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4cc15208ead4462c9da869a61d1369ed",
+       "model_id": "c90364c63db54950924a355f923c8acb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -912,187 +905,7 @@
       "Done building rows\n",
       "Done cleaning\n",
       "Done handling dates\n",
-      "saving to content/tei4publisher/DAFANCH96_023MIC07633_L-0-tei.xml\n",
-      "-------: DAFANCH96_023MIC07645_L-0.xml :-------\n",
-      "starting conversion\n",
-      "conversion finished\n",
-      "Done parsing file\n",
-      "Done updating teiHeader\n",
-      "Done building table structure\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34e70c9c676449c4b368fb2cdef709b1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/18 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done building rows\n",
-      "Done cleaning\n",
-      "Done handling dates\n",
-      "saving to content/tei4publisher/DAFANCH96_023MIC07645_L-0-tei.xml\n",
-      "-------: FRAN_0025_3056_L-0.xml :-------\n",
-      "starting conversion\n",
-      "conversion finished\n",
-      "Done parsing file\n",
-      "Done updating teiHeader\n",
-      "Done building table structure\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7c0b5a3d194c4914a54b7c9bc22f6d98",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/19 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done building rows\n",
-      "Done cleaning\n",
-      "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_3056_L-0-tei.xml\n",
-      "-------: FRAN_0025_1290_L-1.xml :-------\n",
-      "starting conversion\n",
-      "conversion finished\n",
-      "Done parsing file\n",
-      "Done updating teiHeader\n",
-      "Done building table structure\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6b96c7756451484bbc666ffcb043be35",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/21 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done building rows\n",
-      "Done cleaning\n",
-      "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_1290_L-1-tei.xml\n",
-      "-------: FRAN_0025_5094_L-1.xml :-------\n",
-      "starting conversion\n",
-      "conversion finished\n",
-      "Done parsing file\n",
-      "Done updating teiHeader\n",
-      "Done building table structure\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "735001c7a3f549e4ad370b7ea76b1a8c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/21 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done building rows\n",
-      "Done cleaning\n",
-      "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_5094_L-1-tei.xml\n",
-      "-------: FRAN_0025_4648_L-1.xml :-------\n",
-      "starting conversion\n",
-      "conversion finished\n",
-      "Done parsing file\n",
-      "Done updating teiHeader\n",
-      "Done building table structure\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ec69685366504c9a9543c496b4228a42",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/33 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done building rows\n",
-      "Done cleaning\n",
-      "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_4648_L-1-tei.xml\n",
-      "-------: FRAN_0025_5795_L-1.xml :-------\n",
-      "starting conversion\n",
-      "conversion finished\n",
-      "Done parsing file\n",
-      "Done updating teiHeader\n",
-      "Done building table structure\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f68a9b45406948c493fd072e34495052",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/14 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done building rows\n",
-      "Done cleaning\n",
-      "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_5795_L-1-tei.xml\n",
+      "saving to content/tei4publisher/DAFANCH96_023MIC07633_L-0.tei.xml\n",
       "-------: FRAN_0025_0227_L-0.xml :-------\n",
       "starting conversion\n",
       "conversion finished\n",
@@ -1104,7 +917,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "64e77e1799cc455da9389c25d57af11a",
+       "model_id": "10752d55f3d14ae99a744f44b6e5b3fe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1122,7 +935,127 @@
       "Done building rows\n",
       "Done cleaning\n",
       "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_0227_L-0-tei.xml\n",
+      "saving to content/tei4publisher/FRAN_0025_0227_L-0.tei.xml\n",
+      "-------: FRAN_0025_3657_L-1.xml :-------\n",
+      "starting conversion\n",
+      "conversion finished\n",
+      "Done parsing file\n",
+      "Done updating teiHeader\n",
+      "Done building table structure\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "737fb125cf174e8186e0fb4337879aeb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done building rows\n",
+      "Done cleaning\n",
+      "Done handling dates\n",
+      "saving to content/tei4publisher/FRAN_0025_3657_L-1.tei.xml\n",
+      "-------: DAFANCH96_023MIC07645_L-0.xml :-------\n",
+      "starting conversion\n",
+      "conversion finished\n",
+      "Done parsing file\n",
+      "Done updating teiHeader\n",
+      "Done building table structure\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "940952d7a1944019a4b62891a9ba035e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/18 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done building rows\n",
+      "Done cleaning\n",
+      "Done handling dates\n",
+      "saving to content/tei4publisher/DAFANCH96_023MIC07645_L-0.tei.xml\n",
+      "-------: FRAN_0025_5795_L-1.xml :-------\n",
+      "starting conversion\n",
+      "conversion finished\n",
+      "Done parsing file\n",
+      "Done updating teiHeader\n",
+      "Done building table structure\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b1fe818cd71846269ce7a4cd15f2322e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/14 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done building rows\n",
+      "Done cleaning\n",
+      "Done handling dates\n",
+      "saving to content/tei4publisher/FRAN_0025_5795_L-1.tei.xml\n",
+      "-------: FRAN_0025_4648_L-1.xml :-------\n",
+      "starting conversion\n",
+      "conversion finished\n",
+      "Done parsing file\n",
+      "Done updating teiHeader\n",
+      "Done building table structure\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "319516b26fad4dd1902304f0cf4f61c5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/33 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done building rows\n",
+      "Done cleaning\n",
+      "Done handling dates\n",
+      "saving to content/tei4publisher/FRAN_0025_4648_L-1.tei.xml\n",
       "-------: FRAN_0025_6067_L-1.xml :-------\n",
       "starting conversion\n",
       "conversion finished\n",
@@ -1134,7 +1067,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a54b0443bb4f4bbb8861f5160791da2b",
+       "model_id": "1377a87afd6b44e68865c8c2b292a1b7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1152,7 +1085,67 @@
       "Done building rows\n",
       "Done cleaning\n",
       "Done handling dates\n",
-      "saving to content/tei4publisher/FRAN_0025_6067_L-1-tei.xml\n"
+      "saving to content/tei4publisher/FRAN_0025_6067_L-1.tei.xml\n",
+      "-------: FRAN_0025_1290_L-1.xml :-------\n",
+      "starting conversion\n",
+      "conversion finished\n",
+      "Done parsing file\n",
+      "Done updating teiHeader\n",
+      "Done building table structure\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "93250b9317404ebaa0fb1df20e85c56c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/21 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done building rows\n",
+      "Done cleaning\n",
+      "Done handling dates\n",
+      "saving to content/tei4publisher/FRAN_0025_1290_L-1.tei.xml\n",
+      "-------: FRAN_0025_3056_L-0.xml :-------\n",
+      "starting conversion\n",
+      "conversion finished\n",
+      "Done parsing file\n",
+      "Done updating teiHeader\n",
+      "Done building table structure\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9b58524b9e074b0d808cb9af8b408fec",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/19 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done building rows\n",
+      "Done cleaning\n",
+      "Done handling dates\n",
+      "saving to content/tei4publisher/FRAN_0025_3056_L-0.tei.xml\n"
      ]
     }
    ],
@@ -1174,7 +1167,7 @@
     "        rows.append(current_row)\n",
     "    \n",
     "    # generate tei file\n",
-    "    tei_file = source.replace(\".xml\", \"-tei.xml\").replace(\"/source/\", \"/tei_output/\")\n",
+    "    tei_file = source.replace(\".xml\", \".tei.xml\").replace(\"/source/\", \"/tei_output/\")\n",
     "    \n",
     "    # java doit être installé\n",
     "    print(\"starting conversion\")\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jupyter==1.0.0
 lxml==4.2.6
 tqdm==4.62.3
 fuzzywuzzy==0.18.0
+requests==2.26.0


### PR DESCRIPTION
Requests library was added to the `requirements.txt` file, and is now imported in the notebook. 

Since the XSLT now generates a TEI file name such as `[placeholder].tei.xml`, the pipeline is currently crashing because it uses the previous TEI file name, `[placeholder]-tei.xml`. Code cell is now updated.